### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/AzureDevOps-learning-for-Az-400/e567f1e3-a073-44fb-9f75-9104da70707a/04d5aae0-c346-407d-996c-5cc2a66fcdd9/_apis/work/boardbadge/bc009512-37c4-4dbd-8106-d7f6a1149ff2)](https://dev.azure.com/AzureDevOps-learning-for-Az-400/e567f1e3-a073-44fb-9f75-9104da70707a/_boards/board/t/04d5aae0-c346-407d-996c-5cc2a66fcdd9/Microsoft.RequirementCategory)
 # Azure_DevOps
 some scripts and documents 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#31](https://dev.azure.com/AzureDevOps-learning-for-Az-400/e567f1e3-a073-44fb-9f75-9104da70707a/_workitems/edit/31). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.